### PR TITLE
Member Memory

### DIFF
--- a/src/org/magiclib/Magic_modPlugin.java
+++ b/src/org/magiclib/Magic_modPlugin.java
@@ -5,6 +5,7 @@ import com.fs.starfarer.api.EveryFrameScript;
 import com.fs.starfarer.api.Global;
 import com.fs.starfarer.api.campaign.SectorAPI;
 import com.thoughtworks.xstream.XStream;
+import org.magiclib.util.memberMemory.MemberMemoryManager;
 import org.lwjgl.util.vector.Vector2f;
 import org.magiclib.achievements.MagicAchievementManager;
 import org.magiclib.achievements.TestingAchievementSpec;
@@ -158,6 +159,8 @@ public class Magic_modPlugin extends BaseModPlugin {
 //        MagicPaintjobManager.getInstance().diable$MagicLib();
 
         MagicPaintjobManager.onGameLoad();
+
+        MemberMemoryManager.onGameLoad();
     }
 
     @Override
@@ -169,6 +172,7 @@ public class Magic_modPlugin extends BaseModPlugin {
 
         MagicAchievementManager.getInstance().beforeGameSave();
         MagicPaintjobManager.beforeGameSave();
+        MemberMemoryManager.beforeGameSave();
     }
 
     @Override

--- a/src/org/magiclib/Magic_modPlugin.java
+++ b/src/org/magiclib/Magic_modPlugin.java
@@ -159,8 +159,6 @@ public class Magic_modPlugin extends BaseModPlugin {
 //        MagicPaintjobManager.getInstance().diable$MagicLib();
 
         MagicPaintjobManager.onGameLoad();
-
-        MemberMemoryManager.onGameLoad();
     }
 
     @Override

--- a/src/org/magiclib/util/memberMemory/MemberMemoryAccess.kt
+++ b/src/org/magiclib/util/memberMemory/MemberMemoryAccess.kt
@@ -1,37 +1,20 @@
 package org.magiclib.util.memberMemory
 
-import com.fs.starfarer.api.Global
+import org.magiclib.util.memberMemory.MemberMemoryManager.getMemberMemoryStore
 
 object MemberMemoryAccess {
     const val SECTOR_MEMBER_MEMORY_KEY = "\$ML_MemberMemoryStore"
 
-    private fun storeOrNull(): MemberMemoryStore? {
-        val store = MemberMemoryManager.getMemberMemoryStore()
-        if (store == null) {
-            Global.getLogger(this::class.java).error(
-                "MemberMemoryStore is null." +
-                        "\nThe MemberMemoryStore loads in the onGameLoad of MagicLib. If your mod tries to get the memory of a member in onGameLoad and your mod is sooner in load order than MagicLib, an emptyMap will be returned." +
-                        "\nYou may need to wait for MagicLib's onGameLoad to occur before running your code."
-            )
-        }
-        return store
-    }
-
     /**
-     * Only functions in the campaign. Does not function anywhere else.
-     *
-     * The [MemberMemoryStore] loads in the onGameLoad of MagicLib. If your mod tries to get the memory of a member in onGameLoad and your mod is sooner in load order than MagicLib, an emptyMap will be returned.
-     * You may need to wait for MagicLib's onGameLoad to occur before running your code. An error will show up in the log if this happens.
-     *
-     * Member must be present in either an active fleet or in storage before game save, otherwise the memory related to it will be removed as it is considered no longer existing.
+     * Member must be present in either an active fleet or in storage before game save, otherwise the memory related to it will be removed on game save as it is considered no longer existing.
      */
     @JvmStatic
     fun getMemberMemory(memberID: String): MutableMap<String, Any?> {
-        return storeOrNull()?.getMemberMemory(memberID) ?: mutableMapOf()
+        return getMemberMemoryStore().getMemberMemory(memberID)
     }
 
     @JvmStatic
     fun unsetMemberMemory(memberID: String) {
-        storeOrNull()?.unsetMemberMemory(memberID)
+        getMemberMemoryStore().unsetMemberMemory(memberID)
     }
 }

--- a/src/org/magiclib/util/memberMemory/MemberMemoryAccess.kt
+++ b/src/org/magiclib/util/memberMemory/MemberMemoryAccess.kt
@@ -1,0 +1,37 @@
+package org.magiclib.util.memberMemory
+
+import com.fs.starfarer.api.Global
+
+object MemberMemoryAccess {
+    const val SECTOR_MEMBER_MEMORY_KEY = "\$ML_MemberMemoryStore"
+
+    private fun storeOrNull(): MemberMemoryStore? {
+        val store = MemberMemoryManager.getMemberMemoryStore()
+        if (store == null) {
+            Global.getLogger(this::class.java).error(
+                "MemberMemoryStore is null." +
+                        "\nThe MemberMemoryStore loads in the onGameLoad of MagicLib. If your mod tries to get the memory of a member in onGameLoad and your mod is sooner in load order than MagicLib, an emptyMap will be returned." +
+                        "\nYou may need to wait for MagicLib's onGameLoad to occur before running your code."
+            )
+        }
+        return store
+    }
+
+    /**
+     * Only functions in the campaign. Does not function anywhere else.
+     *
+     * The [MemberMemoryStore] loads in the onGameLoad of MagicLib. If your mod tries to get the memory of a member in onGameLoad and your mod is sooner in load order than MagicLib, an emptyMap will be returned.
+     * You may need to wait for MagicLib's onGameLoad to occur before running your code. An error will show up in the log if this happens.
+     *
+     * Member must be present in either an active fleet or in storage before game save, otherwise the memory related to it will be removed as it is considered no longer existing.
+     */
+    @JvmStatic
+    fun getMemberMemory(memberID: String): MutableMap<String, Any?> {
+        return storeOrNull()?.getMemberMemory(memberID) ?: mutableMapOf()
+    }
+
+    @JvmStatic
+    fun unsetMemberMemory(memberID: String) {
+        storeOrNull()?.unsetMemberMemory(memberID)
+    }
+}

--- a/src/org/magiclib/util/memberMemory/MemberMemoryExt.kt
+++ b/src/org/magiclib/util/memberMemory/MemberMemoryExt.kt
@@ -1,0 +1,13 @@
+package org.magiclib.util.memberMemory
+
+import com.fs.starfarer.api.fleet.FleetMemberAPI
+
+object MemberMemoryExt {
+    /**
+     * Delegate for [MemberMemoryAccess.getMemberMemory]
+     *
+     * It is suggested to read the documentation on what this delegates to before using.
+     */
+    fun FleetMemberAPI.getMemberMemory() =
+        MemberMemoryAccess.getMemberMemory(id)
+}

--- a/src/org/magiclib/util/memberMemory/MemberMemoryManager.kt
+++ b/src/org/magiclib/util/memberMemory/MemberMemoryManager.kt
@@ -1,6 +1,9 @@
 package org.magiclib.util.memberMemory
 
 import com.fs.starfarer.api.Global
+import com.fs.starfarer.api.campaign.CargoAPI
+import com.fs.starfarer.api.campaign.econ.MarketAPI
+import com.fs.starfarer.api.campaign.econ.SubmarketAPI
 import org.magiclib.util.memberMemory.MemberMemoryAccess.SECTOR_MEMBER_MEMORY_KEY
 
 internal object MemberMemoryManager {
@@ -17,11 +20,11 @@ internal object MemberMemoryManager {
     fun beforeGameSave() {
         val store = getOrInitStore()
 
-        if(!store.getMemberIDs().isEmpty()) {
+        if (!store.getMemberIDs().isEmpty()) {
             // This shouldn't ever crash, but if it did, beforeGameSave would be a terrible place for it to happen. So prevent it anyway.
             val mostMemberIDs = try {
-                 getMostMemberIDs()
-            } catch(e: Exception) {
+                getMostMemberIDs()
+            } catch (e: Exception) {
                 Global.getLogger(this.javaClass).error("Failed to get member IDs", e)
                 return
             }
@@ -33,24 +36,106 @@ internal object MemberMemoryManager {
     private fun getMostMemberIDs(): Set<String> {
         val locations = Global.getSector().allLocations
 
-        val submarkets = locations.flatMap { it.allEntities }.mapNotNull { it.market }.flatMap { it.submarketsCopy }
+        val markets = locations
+            .flatMap { it.allEntities }
+            .mapNotNull { it.market }
+            .distinctBy { it.id } // A planet and the planet's station may link to the same market. This prevents that
+
+        val storages = markets
+            .flatMap { it.submarketsCopy }
+            .mapNotNull { it.cargo }
+            .distinctBy { it } // Mods such as Trails of Tooth and Claw share cargo. This avoids that causing mis-reporting duplicated members.
 
         val fleetMembers = listOf(
             locations.flatMap { it.fleets }.map { it.fleetData }, // Ships in active fleets.
-            submarkets.mapNotNull { it.cargo?.mothballedShips },  // Ships in storage.
+            storages.mapNotNull { it.mothballedShips },  // Ships in storage.
         ).flatten().flatMap { it.membersListCopy }
 
         val ids = fleetMembers.map { it.id }
 
         // While there shouldn't be duplicates, let's check just in case.
-        val duplicates = ids.groupingBy { it }.eachCount()
-            .filter { it.value > 1 }
-            .keys
-
-        if (duplicates.isNotEmpty()) {
-            Global.getLogger(this.javaClass).error("Duplicate fleet member IDs detected: $duplicates")
+        if (ids.groupingBy { it }.eachCount().any { it.value > 1 }) {
+            duplicateLocationReporter()
         }
 
         return ids.toSet()
+    }
+
+    private fun duplicateLocationReporter() {
+        val locations = Global.getSector().allLocations
+
+        val markets = locations
+            .flatMap { it.allEntities }
+            .mapNotNull { it.market }
+            .distinctBy { it.id }
+
+        data class StorageRef(
+            val market: MarketAPI,
+            val submarket: SubmarketAPI,
+            val cargo: CargoAPI
+        )
+
+        val storages = markets.flatMap { market ->
+            market.submarketsCopy.mapNotNull { sub ->
+                val cargo = sub.cargo ?: return@mapNotNull null
+                StorageRef(market, sub, cargo)
+            }
+        }.distinctBy { it }
+
+        // id -> list of human-readable locations
+        val idMap = mutableMapOf<String, MutableList<String>>()
+
+        // === ACTIVE FLEETS ===
+        for (loc in locations) {
+            for (fleet in loc.fleets) {
+                val fleetName = fleet.name
+
+                for (member in fleet.fleetData.membersListCopy) {
+                    val id = member.id
+
+                    idMap.getOrPut(id) { mutableListOf() }
+                        .add("Fleet: $fleetName | Ship: ${member.shipName}")
+                }
+            }
+        }
+
+        // === STORAGE (MOTHBALLED SHIPS) ===
+        for (storage in storages) {
+            val sub = storage.submarket
+            val market = storage.market
+            val cargo = storage.cargo
+
+            val mothballed = cargo.mothballedShips ?: continue
+
+            val where = "Storage: ${sub.specId} @ ${market.name}"
+
+            for (member in mothballed.membersListCopy) {
+                val id = member.id
+
+                idMap.getOrPut(id) { mutableListOf() }
+                    .add("$where | Ship: ${member.shipName}")
+            }
+        }
+
+        // === REPORT DUPLICATES ===
+        val sb = StringBuilder()
+        var duplicates = 0
+
+        for ((id, list) in idMap) {
+            if (list.size > 1) {
+                duplicates++
+
+                sb.appendLine("=== DUPLICATE ID: $id ===")
+
+                for (entry in list) {
+                    sb.appendLine("  $entry")
+                }
+                sb.appendLine()
+            }
+        }
+
+        sb.appendLine("Duplicate Member IDs found: $duplicates")
+
+        Global.getLogger(this.javaClass).warn(sb.toString())
     }
 }

--- a/src/org/magiclib/util/memberMemory/MemberMemoryManager.kt
+++ b/src/org/magiclib/util/memberMemory/MemberMemoryManager.kt
@@ -1,6 +1,5 @@
 package org.magiclib.util.memberMemory
 
-import com.fs.starfarer.api.GameState
 import com.fs.starfarer.api.Global
 import org.magiclib.util.memberMemory.MemberMemoryAccess.SECTOR_MEMBER_MEMORY_KEY
 
@@ -10,8 +9,8 @@ internal object MemberMemoryManager {
     private fun getOrInitStore(): MemberMemoryStore {
         val memory = Global.getSector().memoryWithoutUpdate
 
-        return memory.get(SECTOR_MEMBER_MEMORY_KEY) as? MemberMemoryStore
-            ?: MemberMemoryStore().also { memory.set(SECTOR_MEMBER_MEMORY_KEY, it) }
+        return memory?.get(SECTOR_MEMBER_MEMORY_KEY) as? MemberMemoryStore
+            ?: MemberMemoryStore().also { memory?.set(SECTOR_MEMBER_MEMORY_KEY, it) }
     }
 
     @JvmStatic
@@ -19,7 +18,14 @@ internal object MemberMemoryManager {
         val store = getOrInitStore()
 
         if(!store.getMemberIDs().isEmpty()) {
-            val mostMemberIDs = getMostMemberIDs()
+            // This shouldn't ever crash, but if it did, beforeGameSave would be a terrible place for it to happen. So prevent it anyway.
+            val mostMemberIDs = try {
+                 getMostMemberIDs()
+            } catch(e: Exception) {
+                Global.getLogger(this.javaClass).error("Failed to get member IDs", e)
+                return
+            }
+
             store.unsetMembersNotInSet(mostMemberIDs)
         }
     }

--- a/src/org/magiclib/util/memberMemory/MemberMemoryManager.kt
+++ b/src/org/magiclib/util/memberMemory/MemberMemoryManager.kt
@@ -1,18 +1,37 @@
 package org.magiclib.util.memberMemory
 
+import com.fs.starfarer.api.GameState
 import com.fs.starfarer.api.Global
 import org.magiclib.util.memberMemory.MemberMemoryAccess.SECTOR_MEMBER_MEMORY_KEY
 
 internal object MemberMemoryManager {
     private var memberMemoryStore: MemberMemoryStore? = null
-    fun getMemberMemoryStore(): MemberMemoryStore? = memberMemoryStore
+    private var currentGameState: GameState? = null
+    fun getMemberMemoryStore(): MemberMemoryStore = getOrInitStore()
+
+    private fun getOrInitStore(forceReload: Boolean = false): MemberMemoryStore {
+        var existing = memberMemoryStore
+
+        val currentGameState = Global.getCurrentState()
+        if (currentGameState != this.currentGameState || forceReload) {
+            this.currentGameState = currentGameState
+            existing = null
+        }
+
+        if (existing != null) return existing
+
+        val memory = Global.getSector().memoryWithoutUpdate
+
+        val store = memory.get(SECTOR_MEMBER_MEMORY_KEY) as? MemberMemoryStore
+            ?: MemberMemoryStore().also { memory.set(SECTOR_MEMBER_MEMORY_KEY, it) }
+
+        memberMemoryStore = store
+        return store
+    }
 
     @JvmStatic
     fun onGameLoad() {
-        val memory = Global.getSector().memoryWithoutUpdate
-
-        memberMemoryStore = memory.get(SECTOR_MEMBER_MEMORY_KEY) as? MemberMemoryStore
-            ?: MemberMemoryStore().also { memory.set(SECTOR_MEMBER_MEMORY_KEY, it) }
+        getOrInitStore(true)
     }
 
     @JvmStatic

--- a/src/org/magiclib/util/memberMemory/MemberMemoryManager.kt
+++ b/src/org/magiclib/util/memberMemory/MemberMemoryManager.kt
@@ -5,41 +5,18 @@ import com.fs.starfarer.api.Global
 import org.magiclib.util.memberMemory.MemberMemoryAccess.SECTOR_MEMBER_MEMORY_KEY
 
 internal object MemberMemoryManager {
-    private var memberMemoryStore: MemberMemoryStore? = null
-    private var currentGameState: GameState? = null
     fun getMemberMemoryStore(): MemberMemoryStore = getOrInitStore()
 
-    private fun getOrInitStore(forceReload: Boolean = false): MemberMemoryStore {
-        var existing = memberMemoryStore
-
-        val currentGameState = Global.getCurrentState()
-        if (currentGameState != this.currentGameState || forceReload) {
-            this.currentGameState = currentGameState
-            existing = null
-        }
-
-        if (existing != null) return existing
-
+    private fun getOrInitStore(): MemberMemoryStore {
         val memory = Global.getSector().memoryWithoutUpdate
 
-        val store = memory.get(SECTOR_MEMBER_MEMORY_KEY) as? MemberMemoryStore
+        return memory.get(SECTOR_MEMBER_MEMORY_KEY) as? MemberMemoryStore
             ?: MemberMemoryStore().also { memory.set(SECTOR_MEMBER_MEMORY_KEY, it) }
-
-        memberMemoryStore = store
-        return store
-    }
-
-    @JvmStatic
-    fun onGameLoad() {
-        getOrInitStore(true)
     }
 
     @JvmStatic
     fun beforeGameSave() {
-        val store = memberMemoryStore ?: run {
-            Global.getLogger(this.javaClass).error("MemberMemoryStore is null. This should never happen.")
-            return
-        }
+        val store = getOrInitStore()
 
         if(!store.getMemberIDs().isEmpty()) {
             val mostMemberIDs = getMostMemberIDs()

--- a/src/org/magiclib/util/memberMemory/MemberMemoryManager.kt
+++ b/src/org/magiclib/util/memberMemory/MemberMemoryManager.kt
@@ -53,9 +53,9 @@ internal object MemberMemoryManager {
 
         val ids = fleetMembers.map { it.id }
 
-        // While there shouldn't be duplicates, let's check just in case.
+        // While there shouldn't be duplicates in normal circumstances, let's check just in case. If any duplicates exist, it's usually fault of a mod.
         if (ids.groupingBy { it }.eachCount().any { it.value > 1 }) {
-            duplicateLocationReporter()
+            duplicateLocationReporter() // Report where duplicates member IDs are into the log.
         }
 
         return ids.toSet()
@@ -80,7 +80,7 @@ internal object MemberMemoryManager {
                 val cargo = sub.cargo ?: return@mapNotNull null
                 StorageRef(market, sub, cargo)
             }
-        }.distinctBy { it }
+        }.distinctBy { it.cargo }
 
         // id -> list of human-readable locations
         val idMap = mutableMapOf<String, MutableList<String>>()

--- a/src/org/magiclib/util/memberMemory/MemberMemoryManager.kt
+++ b/src/org/magiclib/util/memberMemory/MemberMemoryManager.kt
@@ -1,0 +1,54 @@
+package org.magiclib.util.memberMemory
+
+import com.fs.starfarer.api.Global
+import org.magiclib.util.memberMemory.MemberMemoryAccess.SECTOR_MEMBER_MEMORY_KEY
+
+internal object MemberMemoryManager {
+    private var memberMemoryStore: MemberMemoryStore? = null
+    fun getMemberMemoryStore(): MemberMemoryStore? = memberMemoryStore
+
+    @JvmStatic
+    fun onGameLoad() {
+        val memory = Global.getSector().memoryWithoutUpdate
+
+        memberMemoryStore = memory.get(SECTOR_MEMBER_MEMORY_KEY) as? MemberMemoryStore
+            ?: MemberMemoryStore().also { memory.set(SECTOR_MEMBER_MEMORY_KEY, it) }
+    }
+
+    @JvmStatic
+    fun beforeGameSave() {
+        val store = memberMemoryStore ?: run {
+            Global.getLogger(this.javaClass).error("MemberMemoryStore is null. This should never happen.")
+            return
+        }
+
+        if(!store.getMemberIDs().isEmpty()) {
+            val mostMemberIDs = getMostMemberIDs()
+            store.unsetMembersNotInSet(mostMemberIDs)
+        }
+    }
+
+    private fun getMostMemberIDs(): Set<String> {
+        val locations = Global.getSector().allLocations
+
+        val submarkets = locations.flatMap { it.allEntities }.mapNotNull { it.market }.flatMap { it.submarketsCopy }
+
+        val fleetMembers = listOf(
+            locations.flatMap { it.fleets }.map { it.fleetData }, // Ships in active fleets.
+            submarkets.mapNotNull { it.cargo?.mothballedShips },  // Ships in storage.
+        ).flatten().flatMap { it.membersListCopy }
+
+        val ids = fleetMembers.map { it.id }
+
+        // While there shouldn't be duplicates, let's check just in case.
+        val duplicates = ids.groupingBy { it }.eachCount()
+            .filter { it.value > 1 }
+            .keys
+
+        if (duplicates.isNotEmpty()) {
+            Global.getLogger(this.javaClass).error("Duplicate fleet member IDs detected: $duplicates")
+        }
+
+        return ids.toSet()
+    }
+}

--- a/src/org/magiclib/util/memberMemory/MemberMemoryStore.kt
+++ b/src/org/magiclib/util/memberMemory/MemberMemoryStore.kt
@@ -1,0 +1,43 @@
+package org.magiclib.util.memberMemory
+
+class MemberMemoryStore {
+    // Member ID first, then the key
+    val memKeys: MutableMap<String, MutableMap<String, Any?>> = mutableMapOf()
+
+    fun set(memberID: String, key: String, value: Any?) {
+        val memberMemory = getMemberMemory(memberID)
+        memberMemory[key] = value
+    }
+
+    fun get(memberID: String, key: String): Any? {
+        return getMemberMemory(memberID)[key]
+    }
+
+    fun containsKey(memberID: String, key: String): Boolean {
+        return memKeys[memberID]?.containsKey(key) == true
+    }
+
+    fun unsetKey(memberID: String, key: String) {
+        memKeys[memberID]?.remove(key)
+    }
+
+    fun getMemberIDs(): Set<String> {
+        return memKeys.keys
+    }
+
+    fun unsetMemberMemory(memberID: String) {
+        memKeys.remove(memberID)
+    }
+
+    fun getMemberMemory(memberID: String): MutableMap<String, Any?> {
+        return memKeys[memberID] ?: run {
+            val newMemberMemory = mutableMapOf<String, Any?>()
+            memKeys[memberID] = newMemberMemory
+            newMemberMemory
+        }
+    }
+
+    fun unsetMembersNotInSet(memberIDs: Set<String>) {
+        memKeys.keys.retainAll(memberIDs)
+    }
+}


### PR DESCRIPTION
Gives FleetMemberAPI's a MutableMap<String, Any?> for random data storage.

Data is stored in sector memory in the [MemberMemoryStore] class. The key for each member's map is their member ID

In beforeGameSave, make a set of every FleetMemberAPI's ID in every fleet and submarket storage.
Remove all member memory which isn't in that set, as if they aren't in that set they are assumed to be removed from the game.

I have no idea how "good" this is. Or if it has flaws I am unaware of, let me know.